### PR TITLE
Modernize contact form and update layout

### DIFF
--- a/src/components/forms/FormContact.astro
+++ b/src/components/forms/FormContact.astro
@@ -1,47 +1,75 @@
 ---
 ---
 
-<form action="#">
-    <div class="flex flex-col gap-8">
-        <div>
-            <label for="name">Name</label>
-            <div class="mt-2">
-                <input type="text" name="name" id="name" required />
-            </div>
-        </div>
+<form
+    action="#"
+    class="w-full bg-white p-6 rounded-xl shadow-md flex flex-col gap-6"
+>
+    <div>
+        <label
+            for="name"
+            class="block mb-1 text-sm font-medium text-gray-700"
+            >Nombre</label
+        >
+        <input
+            type="text"
+            name="name"
+            id="name"
+            placeholder="Tu nombre"
+            required
+            class="w-full border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        />
+    </div>
 
-        <div>
-            <label for="email">Email</label>
-            <div class="mt-2 grid grid-cols-1">
-                <input type="email" name="email" id="email" placeholder="you@example.com" required />
-            </div>
-        </div>
+    <div>
+        <label
+            for="email"
+            class="block mb-1 text-sm font-medium text-gray-700"
+            >Correo</label
+        >
+        <input
+            type="email"
+            name="email"
+            id="email"
+            placeholder="tu@correo.com"
+            required
+            class="w-full border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        />
+    </div>
 
-        <div>
-            <label for="message">Message</label>
-            <div class="mt-2">
-                <textarea name="message" id="message" rows="4" required></textarea>
-            </div>
-        </div>
+    <div>
+        <label
+            for="message"
+            class="block mb-1 text-sm font-medium text-gray-700"
+            >Mensaje</label
+        >
+        <textarea
+            name="message"
+            id="message"
+            rows="4"
+            placeholder="¿Cómo podemos ayudarte?"
+            required
+            class="w-full border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-teal-500"
+        ></textarea>
+    </div>
 
-        <div>
-            <button type="submit" class="button button-teal group !px-8">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="size-5 -rotate-45 -mt-1 inline-block mr-1 group-hover:rotate-0 transition duration-300"
-                >
-                    <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
-                    ></path>
-                </svg>
-                Send
-            </button>
-        </div>
+    <div class="text-right">
+        <button type="submit" class="button button-teal group !px-8">
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+                class="size-5 -rotate-45 -mt-1 inline-block mr-1 group-hover:rotate-0 transition duration-300"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5"
+                ></path>
+            </svg>
+            Enviar
+        </button>
     </div>
 </form>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,29 +10,31 @@ import Address from "~/components/Address.astro";
 ---
 
 <Layout>
-	<Section>
-		<Container>
-			<div class="grid grid-cols-1 gap-8 lg:gap-16 xl:gap-24 lg:grid-cols-2">
-				<div>
-					<Heading>
-						<h2 slot="heading-title" class="h2">Contact</h2>
-						<p slot="heading-content">Get in touch with us for any questions or inquiries.</p>
-					</Heading>
+        <Section>
+                <Container>
+                        <div class="grid grid-cols-1 gap-8 lg:gap-16 xl:gap-24 lg:grid-cols-5">
+                                <div class="lg:col-span-2">
+                                        <Heading>
+                                                <h2 slot="heading-title" class="h2">Contacto</h2>
+                                                <p slot="heading-content">
+                                                        ¿Tienes un caso, quieres colaborar o invitar un taller? Escríbenos.
+                                                </p>
+                                        </Heading>
 
-					<FormContact />
-				</div>
+                                        <FormContact />
+                                </div>
 
-				<div>
-					<Heading>
-						<h2 slot="heading-title" class="h2">Location &amp; Hours</h2>
-						<div slot="heading-content">
-							<Address />
-							<TableHours />
-						</div>
-					</Heading>
-					<Map />
-				</div>
-			</div>
-		</Container>
-	</Section>
+                                <div class="lg:col-span-3">
+                                        <Heading>
+                                                <h2 slot="heading-title" class="h2">Ubicación &amp; Horarios</h2>
+                                                <div slot="heading-content">
+                                                        <Address />
+                                                        <TableHours />
+                                                </div>
+                                        </Heading>
+                                        <Map />
+                                </div>
+                        </div>
+                </Container>
+        </Section>
 </Layout>


### PR DESCRIPTION
## Summary
- Translate contact page to Spanish and adjust grid to give form 40% width
- Refresh contact form with modern styles and Spanish placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bac85d1ec8832695462393a6d716a3