### PR TITLE
Center Impacto section and resize vertical carousel

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -113,6 +113,7 @@ p {
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
+  justify-content: center;
 }
 
 .stat {
@@ -129,6 +130,10 @@ p {
 .note {
   font-size: 0.875rem;
   color: #555555;
+}
+
+.impacto-container {
+  text-align: center;
 }
 
 /* Navigation */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,7 @@ import Layout from "~/layouts/Layout.astro";
               </p>
             </article>
           </div>
-          <div class="container">
+          <div class="container impacto-container">
             <h2 id="impacto-title">Impacto</h2>
             <div class="stats">
               <div class="stat">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -149,7 +149,7 @@ section.bg-white {
 
 /* Image and video carousels */
 .v-gallery {
-        @apply overflow-hidden h-96;
+        @apply overflow-hidden h-[31.2rem] w-[90%] mx-auto;
 }
 
 .v-gallery .slider-track {
@@ -158,7 +158,7 @@ section.bg-white {
 }
 
 .v-gallery .slide img {
-        @apply w-full h-96 object-cover;
+        @apply w-full h-[31.2rem] object-cover;
 }
 
 .video-row {


### PR DESCRIPTION
## Summary
- center Impacto container, stats, and note
- enlarge vertical carousel height and reduce its width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bad9ba0d648326a0b752a8ffa4fb39