### PR TITLE
refactor: type duplicateForLoop selector

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -355,8 +355,8 @@ import Layout from "~/layouts/Layout.astro";
     </section>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const duplicateForLoop = (selector) => {
-          const track = document.querySelector(selector);
+        const duplicateForLoop = (selector: string) => {
+          const track = document.querySelector<HTMLElement>(selector);
           if (!track) return;
 
           const items = [...track.children];


### PR DESCRIPTION
## Summary
- type the `duplicateForLoop` helper to accept a `string` selector
- cast `document.querySelector` so duplicated nodes and styles operate on `HTMLElement`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae5a041788326ba674766659cb5fe