### PR TITLE
feat: load prosthesis gallery dynamically

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,14 @@
 ---
 import Layout from "~/layouts/Layout.astro";
+
+const imageImports = import.meta.glob<string>(
+  "../assets/images/protesis/*.{png,jpg,jpeg,webp}",
+  {
+    eager: true,
+    import: "default",
+  }
+);
+const protesisImages: string[] = Object.values(imageImports);
 ---
 <Layout
   title="Fundación Protes Animal – Prótesis de fibra de carbono para animales"
@@ -84,30 +93,11 @@ import Layout from "~/layouts/Layout.astro";
         <div class="parte-b">
           <div id="que-gallery" class="v-gallery" aria-label="Galería vertical" tabindex="0">
             <div class="slider-track">
-              <article class="slide">
-                <img
-                  src="images/fundacion-protes-animal-perro-protesis-fibra-carbono-1.png"
-                  alt="Perro con prótesis de fibra de carbono"
-                />
-              </article>
-              <article class="slide">
-                <img
-                  src="images/fundacion-protes-animal-perro-protesis-fibra-carbono-2.png"
-                  alt="Perro con prótesis de fibra de carbono"
-                />
-              </article>
-              <article class="slide">
-                <img
-                  src="images/fundacion-protes-animal-perro-protesis-fibra-carbono.png"
-                  alt="Perro con prótesis de fibra de carbono"
-                />
-              </article>
-              <article class="slide">
-                <img
-                    src="images/fundacion-protes-animal-perro-protesis-fibra-carbono-4.png"
-                    alt="Perro con prótesis de fibra de carbono"
-                />
-              </article>
+              {protesisImages.map((src) => (
+                <article class="slide">
+                  <img src={src} alt="Perro con prótesis de fibra de carbono" />
+                </article>
+              ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- load prosthesis images from directory using `import.meta.glob`
- render gallery slides automatically by iterating over loaded images
- ensure glob imports are typed as strings to fix Astro build error

## Testing
- `npm run build` *(fails: ImageNotFound: Could not find requested image `/src/assets/images/pets/catrick-swayze.jpg`)*

------
https://chatgpt.com/codex/tasks/task_e_68c001abc97c8326a0d0e35f71a3ce79