### PR TITLE
Evita reinicio tempranero de galería vertical

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -154,7 +154,7 @@ section.bg-white {
 
 .v-gallery .slider-track {
         @apply flex flex-col h-full;
-        animation: scroll-vertical 30s linear infinite;
+        animation: scroll-vertical 30s linear infinite alternate;
 }
 
 .v-gallery .slide img {
@@ -179,6 +179,6 @@ section.bg-white {
                 transform: translateY(0);
         }
         100% {
-                transform: translateY(-50%);
+                transform: translateY(calc(-100% + 35.2rem));
         }
 }


### PR DESCRIPTION
## Summary
- Recorre la galería vertical completa antes de reiniciar
- Desplaza la pista usando `calc(-100% + 35.2rem)` y anima en modo `alternate`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not find requested image `/src/assets/images/members/john-doe.jpg`)*

------
https://chatgpt.com/codex/tasks/task_e_68c00b74efd8832689ad2c1a47e46c41